### PR TITLE
Fix bugs where subcategories are not found

### DIFF
--- a/clients/TistoryClient.py
+++ b/clients/TistoryClient.py
@@ -90,7 +90,7 @@ class TistoryClient:
 
         for item in category_list:
             label = item.find('label').text
-            if label in target_name:
+            if label == target_name:
                 return item.find('id').text
 
         raise ValueError(f'[Error] 티스토리에 해당 카테고리가 없습니다. [{target_name}]')


### PR DESCRIPTION
## 개요
저의 티스토리 카테고리 구성이 john.tistory.com/A/B 되어있는데,
카테고리 A를 먼저 찾게되면 A/B의 category-id가 아닌 A의 category-id값을 반환하기 때문에 문제가 발생합니다.

## 작업사항
- 사용자가 notion table에 입력한 category 아래에 하위 sub-category가 더 있을경우 못찾는 문제를 해결하였습니다.

## 변경로직
- if label in target_name:
=> if label == target_name: 