### PR TITLE
Fix: 메일 전송로직 하드코딩 제거

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,10 +157,10 @@ if __name__ == '__main__':
         # create Notion2Tistory client
         client = Notion2Tistory(cfg, sleep_time=5, selenium_debug=False)
         client.posts()
-        title, content = get_mail_content_from_pages(client.pages)
+        title, content = get_mail_content_from_pages(client.pages, cfg)
     except Exception as e:
         print(e)
-        title, _ = get_mail_content_from_pages(None)
+        title, _ = get_mail_content_from_pages(None, cfg)
         content = str(e)
 
     # send alert mail

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -5,11 +5,12 @@ from shutil import rmtree
 import zipfile
 from bs4 import BeautifulSoup
 
-
-def get_mail_content_from_pages(pages):
+def get_mail_content_from_pages(pages, cfg):
     """pages 객체배열로부터 메일로 보낼 content 문자열 가져오기
     pages: 2차원 array [[page, post_id], ...]
     """
+    url_column = cfg.NOTION.COLUMN.URL
+
     if pages is None:
         title = '[노션 알림] Notion2Tistory 에러 발생'
         content = ''
@@ -26,7 +27,7 @@ def get_mail_content_from_pages(pages):
     # 메일 내용
     content = f'총 {len(pages)}개의 게시물이 업로드/수정 되었습니다.\n'
     for i, page in enumerate(pages):
-        content += f' {i + 1}. ' + page[0].title + f' ({page[0].get_property("링크")})\n'
+        content += f' {i + 1}. ' + page[0].title + f' ({page[0].get_property(url_column)})\n'
 
     return title, content
 


### PR DESCRIPTION
- 메일 전송부에 page[0].get_property("링크") 와 같은 형태로 하드코딩되어 있었음.
- config.py 파일에서 값을 가져올 수 있도록 수정.