### PR TITLE
노션에서 카테고리를 입력하지 않을 시 발생하는 에러 수정 && webdriver.Chome 함수에서 발생하는 에러 수정

### DIFF
--- a/clients/SeleniumClient.py
+++ b/clients/SeleniumClient.py
@@ -23,7 +23,7 @@ class SeleniumClient:
         options.add_argument("window-size=1920,1080")  # for notion 로그인 버튼
 
         # web driver 시작
-        self.driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
+        self.driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
 
         print('[진행중] Selenium Chrome WebDriver 시작.. ')
         self.driver.implicitly_wait(self.t)

--- a/main.py
+++ b/main.py
@@ -141,7 +141,12 @@ class Notion2Tistory:
         print(f'\t[진행중] parsing 완료... ', end='')
 
         # 카테고리 id를 얻고, posting 요청
-        category_id = self.t_client.get_category_id_from_name(category_str)
+        # 카테고리 미입력시 None
+        if category_str: 
+            category_id = self.t_client.get_category_id_from_name(category_str)
+        else:
+            category_id = None
+
         resp_post = self.t_client.posting(title=title,
                                           content=content,
                                           visibility=3,


### PR DESCRIPTION
1. 노션에서 카테고리를 입력하지 않을 시 발생하는 에러 수정
카테고리를 입력하지 않을 시 category_str이 None으로 반환되어 get_category_id_from_name함수가 None에 대한 체크 없이 replace 함수를 호출하며 에러 발생
[issues](https://github.com/jmjeon94/N2T/issues/12)

2. webdriver.Chome 함수에서 발생하는 에러 수정
[issues](https://github.com/jmjeon94/N2T/issues/11)