### PR TITLE
notion-py 버전변경

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ selenium
 webdriver_manager
 tqdm
 lxml
-git+https://github.com/wsykala/notion-py.git
+git+https://github.com/jamalex/notion-py.git


### PR DESCRIPTION
안녕하세요.
#24 문제를 동일하게 겪고 notion-py 레포에서 urllib3 라이브러리 업데이트로 인한 오류를 수정했는지 확인해봤습니다.
upstream 레포에서는 해당 에러가 수정되었으나 현재 참조하고 있는 포크 버전에서는 반영이 안되어있었고,
upstream 버전으로 변경하여 설치하니 오류가 해결되었습니다.
다른 의존사항이 있는게 아니시라면 좀더 자주 업데이트되는 버전으로 변경하는게 어떨지 건의드립니다.